### PR TITLE
fix: Resolve KeyError in player data lookup

### DIFF
--- a/mainconnect.py
+++ b/mainconnect.py
@@ -2283,11 +2283,11 @@ def game(manual=True, sentTeamOne=None, sentTeamTwo=None, switch="group"):
     print(team1Players)
 
     for player in team1Players:
-        obj = accessJSON.getPlayerInfo(player)
+        obj = accessJSON.getPlayerInfo(player.upper())
         team1Info.append(obj)
 
     for player in team2Players:
-        obj = accessJSON.getPlayerInfo(player)
+        obj = accessJSON.getPlayerInfo(player.upper())
         team2Info.append(obj)
 
     pitchInfo_ = pitchInfo(venue, typeOfPitch)


### PR DESCRIPTION
The `mainconnect.game()` function was attempting to look up player data from `playerInfoProcessed.json` using player names directly from `teams.json`. The keys in `playerInfoProcessed.json` are in UPPERCASE, while names in `teams.json` were mixed case, leading to a `KeyError`.

This commit modifies `mainconnect.py` to convert player names to uppercase before calling `accessJSON.getPlayerInfo()`. This ensures that the lookup keys match the expected format in the JSON data file.

This fix is expected to resolve the 500 error on the `/api/start_simulation` and `/generate_scorecard` endpoints, which in turn should fix the JavaScript error related to parsing an HTML error page as JSON.